### PR TITLE
fix: fix version of httpx to 0.27.2 to solve __init__ proxies issue

### DIFF
--- a/analyze/src/integrations/openai/requirements.txt
+++ b/analyze/src/integrations/openai/requirements.txt
@@ -1,2 +1,3 @@
 openai==1.51.2
 click==8.1.7
+httpx==0.27.2

--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -1,2 +1,3 @@
 openai==1.51.2
 click==8.1.7
+httpx==0.27.2


### PR DESCRIPTION
The OpenAI library we are using to generate the summary of the report is using httpx library. Httpx 0.28.0 deprecated the keyword proxies, which OpenAI is using. Temporarily downgrade to 0.27.2 until a fix is out.

See more here
https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332