### PR TITLE
Fix indentation for markdown report

### DIFF
--- a/analyze/action.yaml
+++ b/analyze/action.yaml
@@ -299,13 +299,13 @@ runs:
 
       # Containers
       if [[ -s /tmp/containers.txt ]]; then
-        echo "# Containers" >> /tmp/report_output.md
+        echo "## Containers" >> /tmp/report_output.md
         python3 ${{github.action_path}}/src/json_to_md.py /tmp/containers.txt >> /tmp/report_output.md
       fi
 
       # Hashes
       if [[ -s /tmp/hashes.txt ]]; then
-        echo "# Executable Hashes" >> /tmp/report_output.md
+        echo "## Executable Hashes" >> /tmp/report_output.md
         if ${{ env.VT_API_KEY != '' }}; then
           echo "Querying VirusTotal for hashes"
           python3 ${{github.action_path}}/src/integrations/virustotal/vt_script.py /tmp/hashes.txt --mode hashes >> /tmp/hashes_vt.txt


### PR DESCRIPTION
The summary report is not aligned as expected. This simple PR should fix the indentation from this:

1. Report Details
1.1. Falco events
1.2 Processes
1.3 Written Files
1.4 Contacted IPs
1.5 Contacted DNS Domains
2. Containers
3. Executable Hashes
3.1 Top Connections
4. Report Summary

to this:

1. Report Details
1.1. Falco events
1.2 Processes
1.3 Written Files
1.4 Contacted IPs
1.5 Contacted DNS Domains
1.6 Containers
1.7 Executable Hashes
1.8 Top Connections
2. Report Summary