### PR TITLE
fix: api call for issue comment and always print on github_step_summary

### DIFF
--- a/stop/action.yaml
+++ b/stop/action.yaml
@@ -72,6 +72,7 @@ runs:
       VERBOSE: ${{ inputs.verbose }}
       ACTION_PATH: ${{ github.action_path }}
       PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+      OWNER: ${{ github.repository_owner }}
     run: |
       if [[ "$VERBOSE" == "true" ]]; then
         set -x
@@ -96,10 +97,9 @@ runs:
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Content-Type: application/json" \
             -d "{\"body\": \"***Falco Rules*** \\n\\n ${FILE_CONTENT} \\n\\n Find out more at https://github.com/$REPO/actions/runs/$RUN_ID\"}" \
-            https://api.github.com/repos/$REPO/issues/$PULL_REQUEST_NUMBER/comments
-        else
-          cat /tmp/report_output.md >> $GITHUB_STEP_SUMMARY
+            https://api.github.com/repos/$OWNER/$REPO/issues/$PULL_REQUEST_NUMBER/comments
         fi
+        cat /tmp/report_output.md >> $GITHUB_STEP_SUMMARY
       fi
   
   - name: Upload Capture for Analyze mode


### PR DESCRIPTION
It looks to me that this is the right API endpoint: `/repos/OWNER/REPO/issues/ISSUE_NUMBER/comments`

See:
https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment