### PR TITLE
fix(rules): replace deprecated container.info

### DIFF
--- a/rules/falco_cicd_rules.yaml
+++ b/rules/falco_cicd_rules.yaml
@@ -12,7 +12,7 @@
     comps: [endswith, startswith]
     values:
     - ["Runner.Worker", "/home/runner/work/_temp"]
-  output: A source code file %fd.name was overwritten by process %proc.name (file=%fd.name gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty %container.info)
+  output: A source code file %fd.name was overwritten by process %proc.name (file=%fd.name gparent=%proc.aname[2] ggparent=%proc.aname[3] gggparent=%proc.aname[4] evt_type=%evt.type user=%user.name user_uid=%user.uid user_loginuid=%user.loginuid process=%proc.name proc_exepath=%proc.exepath parent=%proc.pname command=%proc.cmdline terminal=%proc.tty container_id=%container.id container_name=%container.name container_image=%container.image.repository container_image_tag=%container.image.tag)
   priority: WARNING
   tags: [CI/CD]
 


### PR DESCRIPTION
With the release of [Falco v0.41.0](https://github.com/falcosecurity/falco/releases/tag/0.41.0), the `container.info` macro is [deprecated](https://github.com/falcosecurity/falco/pull/354). This PR replaces that macro with the individual constituent fields in the Source Code Overwrite rule output.